### PR TITLE
Limit extension scope to the main Teams app

### DIFF
--- a/browser/app/manifest.json
+++ b/browser/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "description": "__MSG_appDescription__",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "manifest_version": 2,
   "icons": {
     "16": "images/icon-16.png",
@@ -9,8 +9,8 @@
   },
   "default_locale": "en",
   "permissions": [
-    "http://teams.microsoft.com/*",
-    "https://teams.microsoft.com/*"
+    "http://teams.microsoft.com/_",
+    "https://teams.microsoft.com/_"
   ],
   "options_ui": {
     "page": "popup.html"
@@ -21,8 +21,8 @@
   },
   "content_scripts": [{
     "matches": [
-      "http://teams.microsoft.com/*",
-      "https://teams.microsoft.com/*"
+      "http://teams.microsoft.com/_",
+      "https://teams.microsoft.com/_"
     ],
     "js": [
       "lib/jquery-3.4.1.min.js",


### PR DESCRIPTION
There are several things running on the **teams.microsoft.com** domain. However, the main Teams app runs under **teams.microsoft.com/_** path. Outside of this path the extension:
- will not work
- will pollute the global namespace with errors happening in **setInterval** in **bulk-add-team-members.js** and **multitenant-panel.js**

Taking this into account, I propose to limit extension scope to **teams.microsoft.com/_** path. Thank you for understanding.